### PR TITLE
run task scheduler in separate thread

### DIFF
--- a/dane_server/server.py
+++ b/dane_server/server.py
@@ -69,7 +69,7 @@ def main():
         s_handler = Handler(config=cfg, queue=publishQueue)
         # TODO make interval configable
         scheduler = TaskScheduler(handler=s_handler, logger=logger, interval=5)
-        scheduler.run()
+        scheduler.start()
     else:
         logger.info(os.environ['SUPERVISOR_PROCESS_NAME'] + ' started without task scheduler')
 


### PR DESCRIPTION
To run in separate thread we need to call start() instead of run(). 
Otherwise the current thread blocks and no listener for response queue will be registered.