### PR TITLE
added creator endpoint for fetching tasks/results of a single creator/batch

### DIFF
--- a/dane_server/RabbitMQPublisher.py
+++ b/dane_server/RabbitMQPublisher.py
@@ -25,9 +25,6 @@ class RabbitMQPublisher(RabbitMQHandler):
     def __init__(self, config):
         super().__init__(config)
 
-    def assign_callback(self, callback):
-        self.callback = callback
-
     def publish(self, routing_key, task, document, retry=False):
         try:
             super().publish(routing_key, task, document, retry)

--- a/dane_server/RabbitMQPublisher.py
+++ b/dane_server/RabbitMQPublisher.py
@@ -16,6 +16,7 @@
 import pika
 import logging
 from dane.handlers import RabbitMQHandler
+from dane.state import ProcState
 
 logger = logging.getLogger("DANE")
 
@@ -31,7 +32,10 @@ class RabbitMQPublisher(RabbitMQHandler):
         try:
             super().publish(routing_key, task, document, retry)
         except pika.exceptions.UnroutableError:
-            fail_resp = {"state": 422, "message": "Unroutable task"}
+            fail_resp = {
+                "state": ProcState.NO_ROUTE_TO_QUEUE.value,
+                "message": "Unroutable task",
+            }
             self.callback(task._id, fail_resp)
             pass
         except Exception as e:

--- a/dane_server/api.py
+++ b/dane_server/api.py
@@ -742,7 +742,7 @@ class WorkersAPI(Resource):
                     ],
                     "must_not": [
                         {"match": {"task.state": ProcState.QUEUED.value}},
-                        {"match": {"task.state": ProcState.PROCESSING.value}},
+                        # {"match": {"task.state": ProcState.PROCESSING.value}}, TODO later
                         {"match": {"task.state": ProcState.SUCCESS.value}},
                         {"match": {"task.state": ProcState.CREATED.value}},
                         {"match": {"task.state": ProcState.UNFINISHED_DEPENDENCY}},

--- a/dane_server/api.py
+++ b/dane_server/api.py
@@ -799,6 +799,19 @@ class WorkerResetAPI(Resource):
             return {"total": 0, "error": e}
 
 
+@ns_creator.route("/<creator_id>/docs")
+class CreatorDocsAPI(Resource):
+    @ns_creator.marshal_with(_document, as_list=True)
+    def get(self, creator_id):
+        try:
+            docs = get_handler().get_docs_of_creator(creator_id, [])
+        except Exception:
+            logger.exception("Unhandled Error")
+            abort(500)
+        else:
+            return docs
+
+
 @ns_creator.route("/<creator_id>/<task_key>/tasks")
 class CreatorTasksAPI(Resource):
     @ns_creator.marshal_with(_task, as_list=True)
@@ -895,6 +908,7 @@ def get_queue():
 
 def get_handler():
     if "handler" not in g:
+        logger.info("No handler assigned yet, assigning it now")
         g.handler = Handler(config=cfg, queue=get_queue())
         queue = get_queue()
         if queue:

--- a/dane_server/api.py
+++ b/dane_server/api.py
@@ -799,12 +799,12 @@ class WorkerResetAPI(Resource):
             return {"total": 0, "error": e}
 
 
-@ns_creator.route("/<creator_id>/tasks")
+@ns_creator.route("/<creator_id>/<task_key>/tasks")
 class CreatorTasksAPI(Resource):
     @ns_creator.marshal_with(_task, as_list=True)
-    def get(self, creator_id):
+    def get(self, creator_id, task_key):
         try:
-            tasks = get_handler().get_tasks_of_creator(creator_id, [])
+            tasks = get_handler().get_tasks_of_creator(creator_id, task_key, [])
         except Exception:
             logger.exception("Unhandled Error")
             abort(500)
@@ -812,12 +812,12 @@ class CreatorTasksAPI(Resource):
             return tasks
 
 
-@ns_creator.route("/<creator_id>/results")
+@ns_creator.route("/<creator_id>/<task_key>/results")
 class CreatorResultsAPI(Resource):
     @ns_creator.marshal_with(_result, as_list=True)
-    def get(self, creator_id):
+    def get(self, creator_id, task_key):
         try:
-            results = get_handler().get_results_of_creator(creator_id, [])
+            results = get_handler().get_results_of_creator(creator_id, task_key, [])
         except Exception:
             logger.exception("Unhandled Error")
             abort(500)

--- a/dane_server/handler.py
+++ b/dane_server/handler.py
@@ -22,4 +22,5 @@ logger = logging.getLogger("DANE")
 class Handler(ESHandler):
     def __init__(self, config, queue):
         super().__init__(config, queue)
+        # assigns the ESHandler.callback() to the RabbitMQPublisher
         self.queue.assign_callback(self.callback)

--- a/dane_server/server.py
+++ b/dane_server/server.py
@@ -62,10 +62,12 @@ def main():
     if "SUPERVISOR_PROCESS_NAME" not in os.environ or os.environ[
         "SUPERVISOR_PROCESS_NAME"
     ].endswith("_00"):
-        publishQueue = RabbitMQPublisher(cfg)
-        s_handler = Handler(config=cfg, queue=publishQueue)
+        # The Handler wraps an ESHandler and assigns a RabbitMQPublisher as queue
+        es_handler_with_queue = Handler(config=cfg, queue=RabbitMQPublisher(cfg))
         # TODO make interval configable
-        scheduler = TaskScheduler(handler=s_handler, logger=logger, interval=5)
+        scheduler = TaskScheduler(
+            handler=es_handler_with_queue, logger=logger, interval=5
+        )
         scheduler.start()
     else:
         logger.info(

--- a/dane_server/web/js/index.js
+++ b/dane_server/web/js/index.js
@@ -263,7 +263,7 @@ Vue.component('dane-tasklist', {
       colour: function(s) {
         if ([200].includes(parseInt(s))) {
           return 'green';
-        } else if ([102, 201, 205].includes(parseInt(s))) {
+        } else if ([102, 202, 201, 205].includes(parseInt(s))) {
           return 'yellow';
         } else {
           return 'red';

--- a/scripts/local-rebuild.sh
+++ b/scripts/local-rebuild.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# run this after you've built a new version of DANE
+
+poetry remove dane
+poetry add ../DANE/dist/*.whl
+poetry build

--- a/scripts/pre-commit-build.sh
+++ b/scripts/pre-commit-build.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# run this to install dane-workflows from github
+if poetry remove dane; then
+    echo "successfully uninstalled dane"
+else
+    echo "dane already uninstalled"
+fi
+
+poetry add dane


### PR DESCRIPTION
Moved functions from dane-workflows to the API, so any client of the DANE API can do without calling the underlying DANE Elasticsearch cluster (which is undesireable for several reasons).


relies on [this PR/branch](https://github.com/CLARIAH/DANE/pull/16) of DANE 
